### PR TITLE
[compile] resolved wrong dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,12 +31,14 @@
         "lodash": "4.17.21"
     },
     "devDependencies": {
-        "@diia-inhouse/configs": "1.26.3",
-        "@diia-inhouse/eslint-config": "3.4.0",
-        "@diia-inhouse/types": "4.25.0",
+        "@diia-inhouse/configs": "^1.26.3",
+        "@diia-inhouse/eslint-config": "^3.4.0",
+        "@diia-inhouse/types": "^5.0.0",
         "@types/lodash": "4.14.201",
         "copyfiles": "2.4.1",
-        "protobufjs": "7.2.5"
+        "protobufjs": "7.2.5",
+        "typescript": "5.2.2",
+        "type-fest": "4.8.1"
     },
     "release": {
         "extends": "@diia-inhouse/configs/dist/semantic-release/package",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,6 @@
         "sourceMap": true,
         "strict": true
     },
-    "include": ["./src/**/*.ts"]
+    "include": ["./src/**/*.ts"],
+    "exclude": ["node_modules"]
 }


### PR DESCRIPTION
**Overview**

- during `npm install` dependencies resolved to wrong/old values, as result it does not work
- @diia-inhouse/* - dependencies point on old versions

**Solution**

- add typescript and type-fest dependencies with exact versions into package.json
- fix in-house dependencies, allow usage of published versions


